### PR TITLE
Fix test failure due to hard-coded filenames.

### DIFF
--- a/t/04codelocation-pureperl.t
+++ b/t/04codelocation-pureperl.t
@@ -15,7 +15,7 @@ sub newton {
 *hooke = *newton;
 for ( \&newton, \&hooke ) {
     my ($file, $line) = get_code_location($_);
-    is( $file, 't/04codelocation-pureperl.t', 'file' );
+    is( $file, $0, 'file' );
     is( $line, 7, 'line' );
 }
 {

--- a/t/04codelocation.t
+++ b/t/04codelocation.t
@@ -15,7 +15,7 @@ sub newton {
 *hooke = *newton;
 for ( \&newton, \&hooke ) {
     my ($file, $line) = get_code_location($_);
-    is( $file, 't/04codelocation.t', 'file' );
+    is( $file, $0, 'file' );
     is( $line, 7, 'line' );
 }
 {


### PR DESCRIPTION
Tests assume Unix style directory separators in filenames which now fail on Windows with `nmake`. Use `$0` instead of hard-coded name to fix. The problem went unnoticed until a recent change in EUMM. See http://blog.nu42.com/2014/12/what-is-really-broken.html
