### PR TITLE
use explicit . for Perls where it is missing from @INC

### DIFF
--- a/t/01basic-pureperl.t
+++ b/t/01basic-pureperl.t
@@ -1,3 +1,3 @@
 #!perl
 BEGIN { $ENV{PERL_SUB_IDENTIFY_PP} = 1 }
-do 't/01basic.t';
+do './t/01basic.t';

--- a/t/04codelocation-pureperl.t
+++ b/t/04codelocation-pureperl.t
@@ -1,3 +1,3 @@
 #!perl
 BEGIN { $ENV{PERL_SUB_IDENTIFY_PP} = 1 }
-do 't/04codelocation.t'
+do './t/04codelocation.t'

--- a/t/05constant-pureperl.t
+++ b/t/05constant-pureperl.t
@@ -1,3 +1,3 @@
 #!perl
 BEGIN { $ENV{PERL_SUB_IDENTIFY_PP} = 1 }
-do 't/05constant.t';
+do './t/05constant.t';

--- a/t/06codelocxs-pureperl.t
+++ b/t/06codelocxs-pureperl.t
@@ -1,4 +1,4 @@
 #!perl
 
 BEGIN { $ENV{PERL_SUB_IDENTIFY_PP} = 1 }
-do 't/06codelocxs.t'
+do './t/06codelocxs.t'

--- a/t/21attributes-pureperl.t
+++ b/t/21attributes-pureperl.t
@@ -2,4 +2,4 @@
 
 BEGIN { $ENV{PERL_SUB_IDENTIFY_PP} = 1 }
 
-require("t/20attributes.t");
+require("./t/20attributes.t");


### PR DESCRIPTION
5.25.7 can be built without . in the `@INC` by default.